### PR TITLE
Prevent polar divide-by-zero in radius search

### DIFF
--- a/test_radius_search.py
+++ b/test_radius_search.py
@@ -1,0 +1,14 @@
+import unittest
+
+from workers import RadiusSearchWorker
+
+class TestRadiusSearchWorker(unittest.TestCase):
+    def test_no_exception_at_pole(self):
+        worker = RadiusSearchWorker('TestDB/TEST.db', 90.0, 0.0, 10)
+        try:
+            worker.run()
+        except Exception as e:
+            self.fail(f"Worker raised exception: {e}")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/workers.py
+++ b/workers.py
@@ -287,7 +287,14 @@ class RadiusSearchWorker(QThread):
             # Convert radius to degrees (approximate)
             # 1 degree of latitude = ~111km
             lat_delta = self.radius / 111000  # Convert meters to degrees
-            lon_delta = lat_delta / abs(math.cos(math.radians(self.latitude)))  # Changed os.cos to math.cos and os.radians to math.radians
+
+            # Avoid division by zero near the poles when computing longitude delta
+            lat_rad = math.radians(self.latitude)
+            cos_lat = math.cos(lat_rad)
+            if abs(cos_lat) < 1e-6:
+                cos_lat = 1e-6
+
+            lon_delta = lat_delta / abs(cos_lat)
             
             # Get images in bounding box
             results = self.db_manager.get_images_in_radius(


### PR DESCRIPTION
## Summary
- avoid division by zero in `RadiusSearchWorker` by clamping the cosine of the latitude
- add regression test ensuring a latitude of 90° doesn't raise an exception

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL'; No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68432c2e42f08330bab116bee9ded3df