### PR TITLE
Handle zero altitude in RadiusSearchWorker

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -326,9 +326,9 @@ class RadiusSearchWorker(QThread):
                     # Check if within radius
                     if distance <= (self.radius / 1000):  # Convert meters to km
                         # Parse altitude if present
-                        if altitude:
+                        if altitude is not None and altitude != '':
                             try:
-                                alt_value = float(altitude.replace('m', ''))
+                                alt_value = float(str(altitude).replace('m', ''))
                                 # Apply altitude filters
                                 if self.min_alt is not None and alt_value < self.min_alt:
                                     continue


### PR DESCRIPTION
## Summary
- handle zero altitude in RadiusSearchWorker so 0 is not treated as missing

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_684339f8a6c48330b2c9a425dc6fa150