### PR TITLE
Handle missing GPS search results

### DIFF
--- a/database.py
+++ b/database.py
@@ -472,7 +472,50 @@ class DatabaseManager:
                         return lat_candidates[0], lon_candidates[0]
 
                 return None, None
-                
+
         except sqlite3.Error as e:
             logger.error(f"Error detecting GPS columns: {str(e)}")
-            return None, None 
+            return None, None
+
+    def get_images_matching_filters(
+        self,
+        folder: Optional[str] = None,
+        session: Optional[str] = None,
+        tag_filters: Optional[Dict[str, str]] = None,
+    ) -> List[Tuple[str, str, str]]:
+        """Fetch images that match folder/session/tag filters regardless of GPS data.
+
+        Args:
+            folder: Optional folder filter.
+            session: Optional session filter.
+            tag_filters: Optional dictionary mapping tag columns to values.
+
+        Returns:
+            List of tuples ``(path, folder, session)`` for matching images.
+        """
+        try:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+
+                query = f"SELECT path, File_Location_Folder, File_Location_Session FROM {self.table_name} WHERE 1=1"
+                params: Dict[str, Any] = {}
+
+                if folder:
+                    query += " AND File_Location_Folder = :folder"
+                    params["folder"] = folder
+                if session:
+                    query += " AND File_Location_Session = :session"
+                    params["session"] = session
+
+                if tag_filters:
+                    for tag_column, tag_value in tag_filters.items():
+                        param_name = f"tag_{tag_column.lower()}"
+                        query += f" AND {tag_column} = :{param_name}"
+                        params[param_name] = tag_value
+
+                cursor.execute(query, params)
+                return cursor.fetchall()
+
+        except sqlite3.Error as e:
+            logger.error(f"Error getting images by filters: {str(e)}")
+            return []

--- a/exif_extractor_gui.py
+++ b/exif_extractor_gui.py
@@ -40,6 +40,7 @@ from config import (
 SUPPORTED_IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.tiff', '.bmp')
 
 from workers import ExifExtractorWorker, BatchProcessWorker, RadiusSearchWorker # Added RadiusSearchWorker
+from database import DatabaseManager
 from exif_utils import (
     convert_to_degrees, format_gps_timestamp, get_gps_info, 
     format_shutter_speed, parse_dms_string_to_dd, # Added parse_dms_string_to_dd
@@ -2974,6 +2975,13 @@ try:
                     if selected_value != "Any":
                         tag_filter_values[tag_column] = selected_value
 
+            # Store active filters so handle_search_results can access them
+            self.active_search_filters = {
+                'folder': selected_folder if selected_folder != "All Folders" else None,
+                'session': selected_session if selected_session != "All Sessions" else None,
+                'tag_filters': tag_filter_values,
+            }
+
             # Create and start the worker with filters
             self.search_worker = RadiusSearchWorker(
                 self.search_db_path.text(),
@@ -3000,9 +3008,34 @@ try:
             self.selection_counter.setText("Selected: 0 images")
             
             if not results:
-                QMessageBox.information(self, "Search Results", "No images found matching the criteria.")
-                self.select_all_btn.setEnabled(False)
-                self.save_selected_btn.setEnabled(False)
+                db_manager = DatabaseManager(self.search_db_path.text())
+                filters = getattr(self, 'active_search_filters', {
+                    'folder': None,
+                    'session': None,
+                    'tag_filters': {},
+                })
+                missing_gps = db_manager.get_images_matching_filters(
+                    filters.get('folder'),
+                    filters.get('session'),
+                    filters.get('tag_filters'),
+                )
+
+                if missing_gps:
+                    QMessageBox.warning(
+                        self,
+                        "Warning",
+                        f"Found {len(missing_gps)} images matching your filters, but none of them have GPS coordinates."
+                    )
+                    placeholder_results = [
+                        (path, 0, None, folder, session)
+                        for path, folder, session in missing_gps
+                    ]
+                    # Recurse with placeholder results so thumbnails are displayed
+                    self.handle_search_results(placeholder_results)
+                else:
+                    QMessageBox.information(self, "Search Results", "No images found matching the criteria.")
+                    self.select_all_btn.setEnabled(False)
+                    self.save_selected_btn.setEnabled(False)
                 return
             
             # Store image paths for navigation


### PR DESCRIPTION
## Summary
- add `get_images_matching_filters` helper in `DatabaseManager`
- record active filters in `perform_radius_search`
- show warning and reload thumbnails when results lack GPS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68433b08ea1883308de656fa3f129f04