### PR TITLE
Switch RadiusSearchWorker prints to logger

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -19,7 +19,8 @@ def setup_logging(log_dir: str = None) -> None:
     # Create console handler
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
-    console_handler.setLevel(logging.INFO)
+    # Capture debug level messages on the console as well
+    console_handler.setLevel(logging.DEBUG)
     
     # Set up file handler if log directory is provided
     if log_dir:

--- a/workers.py
+++ b/workers.py
@@ -275,14 +275,14 @@ class RadiusSearchWorker(QThread):
     def run(self):
         """Search for images within the specified radius."""
         try:
-            print(f"RadiusSearchWorker DEBUG:")
-            print(f"  Coordinates: {self.latitude}, {self.longitude}")
-            print(f"  Radius: {self.radius}m")
-            print(f"  Folder filter: {self.folder}")
-            print(f"  Session filter: {self.session}")
-            print(f"  Tag filters: {self.tag_filters}")
-            print(f"  Min altitude: {self.min_alt}")
-            print(f"  Max altitude: {self.max_alt}")
+            logger.debug("RadiusSearchWorker DEBUG:")
+            logger.debug(f"  Coordinates: {self.latitude}, {self.longitude}")
+            logger.debug(f"  Radius: {self.radius}m")
+            logger.debug(f"  Folder filter: {self.folder}")
+            logger.debug(f"  Session filter: {self.session}")
+            logger.debug(f"  Tag filters: {self.tag_filters}")
+            logger.debug(f"  Min altitude: {self.min_alt}")
+            logger.debug(f"  Max altitude: {self.max_alt}")
             
             # Convert radius to degrees (approximate)
             # 1 degree of latitude = ~111km
@@ -306,7 +306,7 @@ class RadiusSearchWorker(QThread):
                 self.session,
                 self.tag_filters
             )
-            print(f"Database returned {len(results)} images from bounding box")
+            logger.info(f"Database returned {len(results)} images from bounding box")
             
             # Filter by exact distance and altitude
             images_within_radius = []


### PR DESCRIPTION
## Summary
- log radius search debug info through `logger`
- show debug-level messages in `setup_logging`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473e031c6883308084568bc103b5e7